### PR TITLE
Fix systems

### DIFF
--- a/plover_korean/system/cas/definition.py
+++ b/plover_korean/system/cas/definition.py
@@ -28,7 +28,7 @@ IMPLICIT_HYPHEN_KEYS: Tuple[str] = (
 SUFFIX_KEYS: Tuple[str] = ()
 
 # This system has explicit number keys, so there is no need for these.
-NUMBER_KEY: str = ''
+NUMBER_KEY: str = None
 NUMBERS: Dict[str, str] = {}
 
 # Can be overridden or alternatives can be made in a dictionary.

--- a/plover_korean/system/cas/definition.py
+++ b/plover_korean/system/cas/definition.py
@@ -66,7 +66,7 @@ KEYMAPS: Dict[str, Dict[str, Tuple[str]]] = {
 
 
         '-*': 'v',
-        '-ㅓ': 'k',
+        '-ㅓ': 'b',
         '-ㅣ': 'n',
 
         '-6': '6',

--- a/plover_korean/system/sorizava/definition.py
+++ b/plover_korean/system/sorizava/definition.py
@@ -36,7 +36,7 @@ IMPLICIT_HYPHEN_KEYS: Tuple[str] = (
 SUFFIX_KEYS: Tuple[str] = ()
 
 # This system has explicit number keys, so there is no need for these.
-NUMBER_KEY: str = ''
+NUMBER_KEY: str = None
 NUMBERS: Dict[str, str] = {}
 
 # Can be overridden or alternatives can be made in a dictionary.


### PR DESCRIPTION
The empty string is not a valid system `NUMBER_KEY`, use `None` instead.